### PR TITLE
Repo badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@
     - pip install requests
     - pip install pytest-cov
   script:
-    - cd lambda_func && python -m pytest --cov=.
+    - cd lambda_func && python -m pytest --cov=. --cov-report term-missing
     - cd ..
-    - cd api_testing && python -m pytest --cov=.
+    - cd api_testing && python -m pytest --cov=. --cov-report term-missing
   deploy:
     - provider: lambda
       function_name: "LibbyDevelop"
@@ -42,3 +42,5 @@
       zip: "${TRAVIS_BUILD_DIR}/lambda_func"
       on:
         branch: master
+  after_success:
+      - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@
     - pip install requests
     - pip install pytest-cov
   script:
-    - cd lambda_func && python -m pytest --cov=. --cov-report term-missing
+    - cd lambda_func && python -m pytest --cov=.
     - cd ..
-    - cd api_testing && python -m pytest --cov=. --cov-report term-missing
+    - cd api_testing && python -m pytest --cov=.
   deploy:
     - provider: lambda
       function_name: "LibbyDevelop"
@@ -42,5 +42,3 @@
       zip: "${TRAVIS_BUILD_DIR}/lambda_func"
       on:
         branch: master
-  after_success:
-      - coveralls

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ Libby, the library assistant for Amazon Alexa.
 Libby is a student project by Software Engineering students from Aalto University.
 
 #### Branch master [![Build Status](https://travis-ci.org/NickKuts/Libby.png?branch=master)](https://travis-ci.org/NickKuts/Libby)
-[![Coverage Status](https://coveralls.io/repos/github/NickKuts/Libby/badge.svg?branch=master)](https://coveralls.io/github/NickKuts/Libby?branch=master)
 The master branch of Libby. 
 
 #### Branch develop [![Build Status](https://travis-ci.org/NickKuts/Libby.png?branch=develop)](https://travis-ci.org/NickKuts/Libby)
-[![Coverage Status](https://coveralls.io/repos/github/NickKuts/Libby/badge.svg?branch=develop)](https://coveralls.io/github/NickKuts/Libby?branch=develop)
 The development branch of Libby. Here is where the magic happens.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
+[![Build Status](https://travis-ci.org/NickKuts/Libby.png?branch=master)](https://travis-ci.org/NickKuts/Libby)
+
 # Libby
 Libby, the library assistant for Amazon Alexa

--- a/README.md
+++ b/README.md
@@ -8,4 +8,5 @@ Libby is a student project by Software Engineering students from Aalto Universit
 The master branch of Libby. 
 
 #### Branch develop [![Build Status](https://travis-ci.org/NickKuts/Libby.png?branch=develop)](https://travis-ci.org/NickKuts/Libby)
+[![Coverage Status](https://coveralls.io/repos/github/NickKuts/Libby/badge.svg?branch=develop)](https://coveralls.io/github/NickKuts/Libby?branch=develop)
 The development branch of Libby. Here is where the magic happens.

--- a/README.md
+++ b/README.md
@@ -3,10 +3,8 @@ Libby, the library assistant for Amazon Alexa.
 
 Libby is a student project by Software Engingeering students from Aalto University.
 
-#### Branch master 
-[![Build Status](https://travis-ci.org/NickKuts/Libby.png?branch=master)](https://travis-ci.org/NickKuts/Libby)
+#### Branch master [![Build Status](https://travis-ci.org/NickKuts/Libby.png?branch=master)](https://travis-ci.org/NickKuts/Libby)
 The master branch of Libby. 
 
-#### Branch develop 
-[![Build Status](https://travis-ci.org/NickKuts/Libby.png?branch=develop)](https://travis-ci.org/NickKuts/Libby)
+#### Branch develop [![Build Status](https://travis-ci.org/NickKuts/Libby.png?branch=develop)](https://travis-ci.org/NickKuts/Libby)
 The development branch of Libby. Here is where the magic happens.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-[![Build Status](https://travis-ci.org/NickKuts/Libby.png?branch=master)](https://travis-ci.org/NickKuts/Libby)
-
 # Libby
-Libby, the library assistant for Amazon Alexa
+Libby, the library assistant for Amazon Alexa.
+
+Libby is a student project by Software Engingeering students from Aalto University.
+
+####Branch master [![Build Status](https://travis-ci.org/NickKuts/Libby.png?branch=master)](https://travis-ci.org/NickKuts/Libby)
+The master branch of Libby. 
+
+####Branch develop [![Build Status](https://travis-ci.org/NickKuts/Libby.png?branch=develop)](https://travis-ci.org/NickKuts/Libby)
+The development branch of Libby. Here is where the magic happens.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Libby, the library assistant for Amazon Alexa.
 Libby is a student project by Software Engineering students from Aalto University.
 
 #### Branch master [![Build Status](https://travis-ci.org/NickKuts/Libby.png?branch=master)](https://travis-ci.org/NickKuts/Libby)
+[![Coverage Status](https://coveralls.io/repos/github/NickKuts/Libby/badge.svg?branch=master)](https://coveralls.io/github/NickKuts/Libby?branch=master)
 The master branch of Libby. 
 
 #### Branch develop [![Build Status](https://travis-ci.org/NickKuts/Libby.png?branch=develop)](https://travis-ci.org/NickKuts/Libby)

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@ Libby, the library assistant for Amazon Alexa.
 
 Libby is a student project by Software Engingeering students from Aalto University.
 
-####Branch master 
+#### Branch master 
 [![Build Status](https://travis-ci.org/NickKuts/Libby.png?branch=master)](https://travis-ci.org/NickKuts/Libby)
 The master branch of Libby. 
 
-####Branch develop 
+#### Branch develop 
 [![Build Status](https://travis-ci.org/NickKuts/Libby.png?branch=develop)](https://travis-ci.org/NickKuts/Libby)
 The development branch of Libby. Here is where the magic happens.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Libby
 Libby, the library assistant for Amazon Alexa.
 
-Libby is a student project by Software Engingeering students from Aalto University.
+Libby is a student project by Software Engineering students from Aalto University.
 
 #### Branch master [![Build Status](https://travis-ci.org/NickKuts/Libby.png?branch=master)](https://travis-ci.org/NickKuts/Libby)
 The master branch of Libby. 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@ Libby, the library assistant for Amazon Alexa.
 
 Libby is a student project by Software Engingeering students from Aalto University.
 
-####Branch master [![Build Status](https://travis-ci.org/NickKuts/Libby.png?branch=master)](https://travis-ci.org/NickKuts/Libby)
+####Branch master 
+[![Build Status](https://travis-ci.org/NickKuts/Libby.png?branch=master)](https://travis-ci.org/NickKuts/Libby)
 The master branch of Libby. 
 
-####Branch develop [![Build Status](https://travis-ci.org/NickKuts/Libby.png?branch=develop)](https://travis-ci.org/NickKuts/Libby)
+####Branch develop 
+[![Build Status](https://travis-ci.org/NickKuts/Libby.png?branch=develop)](https://travis-ci.org/NickKuts/Libby)
 The development branch of Libby. Here is where the magic happens.


### PR DESCRIPTION
This simple pull request adds badges for branches `master` and `develop`. This updates each time both branches have their respective Travis build building.

I attempted to add code coverage metric badges, but these were too time consuming with progress so I abandoned them. If someone gets interested in adding such one may check out Coveralls with Travis CLI.