### PR TITLE
Add docker image for debian and raspbian

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
+*~
 **/.idea/**
 **/data_files/
 

--- a/rpi/Dockerfile
+++ b/rpi/Dockerfile
@@ -1,0 +1,26 @@
+FROM debian:stretch
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get install -q -y --no-install-recommends \
+        swig3.0 python-pyaudio python3-pyaudio sox libatlas-base-dev \
+        python-dev python3-dev virtualenv build-essential portaudio19-dev \
+        git-core mpg321 alsa-utils
+
+COPY lex/requirements.txt /rpi/
+RUN virtualenv -p python3 /venv && \
+    /venv/bin/pip install -r /rpi/requirements.txt
+# Workaround to recover snowboydetect.py, which setup.py fails to install:
+RUN make -C venv/src/snowboy/swig/Python3 SWIG=swig3.0
+
+COPY lex /rpi/lex
+RUN tar C /venv/src/snowboy -cf - \
+   swig/Python3/_snowboydetect.so \
+   swig/Python3/snowboydetect.py \
+   examples/Python3/snowboydecoder.py \
+   | tar C /rpi/lex/python/snowboy --strip=2 -xvf -
+
+COPY resources/asound.conf /etc/
+COPY resources/entrypoint /
+
+ENTRYPOINT ["/entrypoint"]

--- a/rpi/Dockerfile
+++ b/rpi/Dockerfile
@@ -1,4 +1,5 @@
-FROM debian:stretch
+ARG BASE=debian
+FROM ${BASE}:stretch
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive \

--- a/rpi/Makefile
+++ b/rpi/Makefile
@@ -3,10 +3,17 @@
 IMAGE := libbypi
 REPO := 263893614267.dkr.ecr.eu-west-1.amazonaws.com
 
+DISTRIBUTOR := $(shell lsb_release -i | expand)
+ifeq ($(DISTRIBUTOR),Distributor ID: Raspbian)
+BASE := resin/rpi-raspbian
+else
+BASE := debian
+endif
+
 TAG := $(shell uname -m)
 
 docker-image:
-	docker build -t $(IMAGE) .
+	docker build -t $(IMAGE) --build-arg BASE=$(BASE) .
 
 push: REMOTE:=$(REPO)/$(IMAGE):$(TAG)
 push:

--- a/rpi/Makefile
+++ b/rpi/Makefile
@@ -1,0 +1,14 @@
+.PHONY: docker-image push
+
+IMAGE := libbypi
+REPO := 263893614267.dkr.ecr.eu-west-1.amazonaws.com
+
+TAG := $(shell uname -m)
+
+docker-image:
+	docker build -t $(IMAGE) .
+
+push: REMOTE:=$(REPO)/$(IMAGE):$(TAG)
+push:
+	docker tag $(IMAGE) $(REMOTE)
+	docker push $(REMOTE)

--- a/rpi/lex/README.md
+++ b/rpi/lex/README.md
@@ -7,6 +7,8 @@ The client is made with Python3 and uses Amazon SDK boto3 to communicate with AW
 
 For wakeword detection, the client uses [Snowboy](https://snowboy.kitt.ai/).  
 
+## Manual installation with install.sh (no docker)
+
 Installation:
 ```
 git clone https://github.com/NickKuts/Libby/tree/develop
@@ -31,10 +33,71 @@ In case you wish to use only the client without snowboy wakeword detection, you 
 python3 run_no_snowboy.py
 ```
 
-The installation script first installs the required libraries, then clones snowboy repository, builds the python3 version of snowboy, moves the built files to the lex working directory and then removes the snowboy repository. 
+The installation script first installs the required libraries, then clones snowboy repository, builds the python3 version of snowboy, moves the built files to the lex working directory and then removes the snowboy repository.
 
 The javascript implementation does not have an installation script, but in case you need to use it, you can follow the guide in https://aws.amazon.com/blogs/machine-learning/build-a-voice-kit-with-amazon-lex-and-a-raspberry-pi/
 
+## Installing an existing docker image from the registry
 
+For deployment.  No libby source code required.  Just install docker:
 
+```
+curl -sSL https://get.docker.com | sh
+systemctl start docker
+```
 
+Pull one the pre-built images, depending on platform:
+
+```
+repo=263893614267.dkr.ecr.eu-west-1.amazonaws.com
+docker pull $repo/libbypi:raspbian    # on Raspberry Pi
+docker pull $repo/libbypi:x86_64      # not on Raspberry Pi
+```
+
+Run a container:
+
+```
+docker run $repo/libbypi:XXX help
+```
+
+The help option show instructions on how to run it in real use:
+
+```
+libbypi docker container
+
+USAGE:
+    docker run \
+        -e AWS_DEFAULT_REGION=eu-west-1 \
+        -e AWS_ACCESS_KEY_ID=... \
+        -e AWS_SECRET_ACCESS_KEY=... \
+        --device /dev/snd --privileged \
+        [-i -t] libbypi MODE
+
+where MODE is one of
+  - run
+  - run_no_snowboy
+  - help (prints this message)
+  - shell (requires -i -t to be usable)
+```
+
+## Rebuilding the docker image
+
+Clone libby.  Then:
+
+```
+cd rpi
+make
+```
+
+And proceed with "docker run" like with a downloaded image:
+
+```
+docker run libbypi help
+```
+
+To tag and push this local image to the ECR registry for other users,
+run "make push".
+
+TODO: currently there is only one tag per platform.  Better release
+discipline might be to have separate develop and master tags, or even
+better, version numbers.

--- a/rpi/lex/README.md
+++ b/rpi/lex/README.md
@@ -80,6 +80,44 @@ where MODE is one of
   - shell (requires -i -t to be usable)
 ```
 
+## ALSA error messages
+
+The docker container is configured to work with USB speaker and
+microphone.  The following error means that the USB device was not
+found:
+
+```
+ALSA lib pcm.c:2495:(snd_pcm_open_noupdate) Unknown PCM sysdefault:CARD=USB
+```
+
+The docker container uses ALSA directly. The following error means that
+the ALSA device is in use.  When running on a laptop, one common reason
+for that would be that pulseaudio is running.  In that case, try
+"pulseaudio --kill".
+
+```
+ALSA lib pcm_dmix.c:1052:(snd_pcm_dmix_open) unable to open slave Can't find a suitable libao driver. (Is device in use?)
+```
+
+And finally, there are some warnings which on their own seem to be
+harmless and can be ignored:
+
+```
+ALSA lib pcm.c:2495:(snd_pcm_open_noupdate) Unknown PCM spdif
+ALSA lib pcm.c:2495:(snd_pcm_open_noupdate) Unknown PCM cards.pcm.hdmi
+ALSA lib pcm.c:2495:(snd_pcm_open_noupdate) Unknown PCM cards.pcm.hdmi
+ALSA lib pcm.c:2495:(snd_pcm_open_noupdate) Unknown PCM cards.pcm.modem
+ALSA lib pcm.c:2495:(snd_pcm_open_noupdate) Unknown PCM cards.pcm.modem
+ALSA lib pcm.c:2495:(snd_pcm_open_noupdate) Unknown PCM cards.pcm.phoneline
+ALSA lib pcm.c:2495:(snd_pcm_open_noupdate) Unknown PCM cards.pcm.phoneline
+```
+
+These warnings are due to the default alsa.conf listing devices that
+don't exist.  With commands like aplay and arecord no warnings are
+printed, but maybe PyAudio probes all devices or something like that.
+Some of the warnings can be fixed by removing some lines from alsa.conf,
+but since the warnings don't hurt, I didn't investigate further.
+
 ## Rebuilding the docker image
 
 Clone libby.  Then:

--- a/rpi/lex/python/run.py
+++ b/rpi/lex/python/run.py
@@ -1,15 +1,19 @@
+import os
+
 from lex import Lex
 from snowboy import snowboydecoder
 from subprocess import run
 
+basedir = os.path.dirname(os.path.abspath(__file__))
+
 lex = Lex()
 stop_recording = False
-model = "Libby.pmdl"
+model = os.path.join(basedir, "Libby.pmdl")
 detector = snowboydecoder.HotwordDetector(model, sensitivity=0.5)
 
 
 def record_and_post():
-    run(['play', 'snowboy/resources/ding.wav'])
+    run(['play', os.path.join(basedir, 'snowboy/resources/ding.wav')])
     response = lex.post_content()
     state = lex.play_response(response)
 
@@ -34,5 +38,3 @@ def detect():
                 interrupt_check=interrupt_callback, sleep_time=0.03)
 
 detect()
-
-

--- a/rpi/lex/requirements.txt
+++ b/rpi/lex/requirements.txt
@@ -1,0 +1,3 @@
+pyaudio==0.2.11
+boto3==1.5.20
+-e git://github.com/Kitt-AI/snowboy.git@4ee48111#egg=snowboy-1.2.0b1+git

--- a/rpi/resources/asound.conf
+++ b/rpi/resources/asound.conf
@@ -1,0 +1,6 @@
+# Sets the default card to USB.
+pcm.!default {
+    type plug
+    slave.pcm "sysdefault:CARD=USB"
+    # slave.pcm "sysdefault:CARD=PCH"
+}

--- a/rpi/resources/entrypoint
+++ b/rpi/resources/entrypoint
@@ -1,0 +1,37 @@
+#!/bin/bash -e
+export PYTHONPATH=/rpi/lex/python
+case $1 in
+    run)
+        /venv/bin/python -m run
+        ;;
+    run_no_snowboy)
+        /venv/bin/python -m run_no_snowboy
+        ;;
+    help|--help)
+        cat <<EOF
+libbypi docker container
+
+USAGE:
+    docker run \\
+        -e AWS_DEFAULT_REGION=eu-west-1 \\
+        -e AWS_ACCESS_KEY_ID=... \\
+        -e AWS_SECRET_ACCESS_KEY=... \\
+        --device /dev/snd --privileged \\
+        [-i -t] libbypi MODE
+
+where MODE is one of
+  - run
+  - run_no_snowboy
+  - help (prints this message)
+  - shell (requires -i -t to be usable)
+
+EOF
+        ;;
+    shell)
+        exec /bin/bash
+        ;;
+    *)
+        echo "unexpected arguments (try help instead)" 1>&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
Note the instructions in the updated README.

There is one docker image for x86_64 based on Debian stretch, e.g. for use on Laptops, and one image for ARM, which is based not on Debian but on Raspbian.

Makefile and Dockerfile can be used to rebuild one of these images from scratch (when running on the matching platform).

To use a pre-built image, docker pull and docker run should be all that is required now to run on a device -- no git checkout needed.

I've pushed images for current develop to the ECR registry.